### PR TITLE
Make vim-bling mappings open folds like builtins do

### DIFF
--- a/plugin/bling.vim
+++ b/plugin/bling.vim
@@ -38,8 +38,8 @@ function! BlingHighight()
 endfunction
 
 if !exists('g:bling_no_map')
-  nnoremap <silent> n n:call BlingHighight()<CR>
-  nnoremap <silent> N N:call BlingHighight()<CR>
-  nnoremap <silent> * *:call BlingHighight()<CR>
-  nnoremap <silent> # #:call BlingHighight()<CR>
+  nnoremap <silent> n nzv:call BlingHighight()<CR>
+  nnoremap <silent> N Nzv:call BlingHighight()<CR>
+  nnoremap <silent> * *zv:call BlingHighight()<CR>
+  nnoremap <silent> # #zv:call BlingHighight()<CR>
 endif


### PR DESCRIPTION
n/N/#/\* open folds when the next match is in one.  This
makes sure vim-bling does too
