### PR TITLE
Wrap search pattern in non-capturing group

### DIFF
--- a/plugin/bling.vim
+++ b/plugin/bling.vim
@@ -19,7 +19,7 @@ function! BlingHighight()
   let param = getreg('/')
   let pos = getpos('.')
 
-  let pattern = '\%'.pos[1].'l\%'.pos[2].'c'.param
+  let pattern = '\%'.pos[1].'l\%'.pos[2].'c\%('.param.'\)'
 
   if &ignorecase == 1 || &smartcase == 1
     let pattern = pattern.'\c'


### PR DESCRIPTION
If you have a search pattern with an alternation in it (ex.
`\<foo\|bar\>`), the pattern fed to match is interpreted as "match
this column/line combo plus the first branch OR the second branch",
resulting in multiple things flashing in the buffer.  This patch
wraps the whole search string in a non-capturing group to prevent
this behavior
