### PR TITLE
Fix typo in documentation for g:bling_color_gui_bg

### DIFF
--- a/doc/bling.txt
+++ b/doc/bling.txt
@@ -68,7 +68,7 @@ Use this option to change forground color of the blink in gui: >
 let g:bling_color_gui_fg = 'red'
 <
 
-                                               *'g:bling_color_gui_fg'* *bling_color_gui_bg*
+                                               *'g:bling_color_gui_bg'* *bling_color_gui_bg*
 Use this option to change background color of the blink in gui: >
 let g:bling_color_gui_bg = 'black'
 <


### PR DESCRIPTION
This was causing `helptags` to fail to run correctly because
g:bling_color_gui_fg appeared multiple times.