### PR TITLE
match search pattern case sensitive

### DIFF
--- a/plugin/bling.vim
+++ b/plugin/bling.vim
@@ -50,7 +50,7 @@ function! BlingHighight()
   let pos = getpos('.')
 
   let pattern = '\%'.pos[1].'l\%'.pos[2].'c\%('.param
-  if match(param, '^\\v') == 0
+  if match(param, '/\c^\\v') == 0
     let pattern = pattern.')'
   else
     let pattern = pattern.'\)'


### PR DESCRIPTION
If a search string starting with \V is passed, this plugin throws an error. This pullrequest will address this by matching pattern case sensitive.

Issue reproduction:
press `gD` on one of the programming symbol and press `n`
