### PR TITLE
Fix bling breaking visual selection via search

### DIFF
--- a/plugin/bling.vim
+++ b/plugin/bling.vim
@@ -82,7 +82,11 @@ endfunction
 
 function! BlingExpressionHighlight()
   let cmd_type = getcmdtype()
-  if cmd_type == '/' || cmd_type == '?'
+  let current_mode = mode()
+  let in_visual_mode = current_mode == "v" ||
+                     \ current_mode == "V" ||
+                     \ current_mode == ""
+  if (cmd_type == '/' || cmd_type == '?') && !in_visual_mode
     return "\<CR>:call BlingHighight()\<CR>"
   endif
   return "\<CR>"


### PR DESCRIPTION
When trying to visually select via searching (both `/` and `?`), as soon as `BlingExpressionHighlight()` is called (after pressing Enter), visual selection is lost and vim starts stepping through every line in the original selection.

The fix is to disable `BlingExpressionHighlight` in visual mode.