### PR TITLE
Use matchaddpos() to add BlingHilight highlight group

### DIFF
--- a/plugin/bling.vim
+++ b/plugin/bling.vim
@@ -47,18 +47,13 @@ function! BlingHighight()
   let sleep_command = 'sleep ' . g:bling_time . 'ms'
 
   let param = getreg('/')
-  let pos = getpos('.')
 
-  let pattern = '\%'.pos[1].'l\%'.pos[2].'c\%('.param
-  if match(param, '/\c^\\v') == 0
-    let pattern = pattern.')'
-  else
-    let pattern = pattern.'\)'
-  endif
-
-  if &ignorecase == 1 || &smartcase == 1
-    let pattern = pattern.'\c'
-  endif
+  " find the start and end columns of the current match so that we can
+  " use matchaddpos below
+  let match_start_pos = getcurpos()
+  call search(param, 'ceW')
+  let match_end_pos = getcurpos()
+  call cursor(match_start_pos[1:])
 
   " open folds
   normal zv
@@ -66,7 +61,7 @@ function! BlingHighight()
   while  blink_count > 0
     let blink_count -= 1
 
-    let ring = matchadd('BlingHilight', pattern)
+    let ring = matchaddpos('BlingHilight', [ [ match_start_pos[1], match_start_pos[2], match_end_pos[2] - match_start_pos[2] + 1 ] ])
     redraw
 
     exec l:sleep_command


### PR DESCRIPTION
This happens to be faster, but it also fixes a bug with certain
patterns.  For example, let's say you search for the pattern `*`.  Even
though this is technically illegal (the `*` pattern metacharacter needs to
follow an argument), Vim helpfully infers that you mean to search for
`*` on its own.   The problem is that when vim-bling does its thing, it
pads the current search pattern with a bunch of other stuff to make sure
only the match at the cursor position is found on the subsequent call to
matchadd(), and Vim is not so forgiving of the technically illegal
pattern here.  As a result, you get a bunch of error messages about
"misplaced *" or something like that, depending on which regexp engine
Vim is using, and the error repeats itself while vim-bling tries to
toggle the match on and off.  You can see this error in action here:

![vim-bling-bug](https://user-images.githubusercontent.com/107804/67161428-0fbc1c00-f320-11e9-8c65-b7037a6d3ce1.gif)

This patch uses Vim's own forgiving search logic to just find
the start and end positions of the match, and then passes them to
matchaddpos()